### PR TITLE
shop.futonwerkstatt.de hinzugefügt

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Das ist eine kuratierte Liste. Heißt, ich schaue mir wirklich all eure Empfehlu
 
 ### 🏡 Wohnen
 * [avocadostore](https://www.avocadostore.de)
+* [futonwerkstatt](https://shop.futonwerkstatt.de/) (Matrazen, Futons, Betten und zubehör. Manufaktur bei Berlin seit 1987)
 
 ### 💶 2nd Hand / Refurbished
 * [cool blue](https://coolblue.de) (verkaufen auch Retouren als "second chance" etwas günstiger wieder)


### PR DESCRIPTION
Beschreibung (von der Webseite):
   Die FUTONWERKSTATT-HOLZWERKSTATT fertigt seit 1987 in Berlin Futons
   und Matratzen aus nachwachsenden Naturmaterialien an. Zudem bieten
   wir eine Auswahl an Bettrahmen, Lattenrosten, Leuchten, Kissen,
   Matten, Paravents, Bettdecken, Bettwäsche und vielem mehr an.

Persönlich gute Erfahrungen mit gemacht, die Familie und ich habe über die letzten 20 Jahre hier unsere Matrizen gekauft.